### PR TITLE
Phase 00 — Bootstrap (fonts + feature flag)

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,3 @@
+# Redesign en curso. Ponerlo en true para ver el nuevo layout en dev.
+# Default: false (production keeps the old UI hasta la Fase 12).
+NEXT_PUBLIC_REDESIGN=false

--- a/apps/frontend/src/app/globals.css
+++ b/apps/frontend/src/app/globals.css
@@ -3,5 +3,5 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 body {
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: var(--font-sans), 'Inter', system-ui, -apple-system, sans-serif;
 }

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,22 +1,21 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import { AuthProvider } from '@/lib/auth-context';
+import { fontSans, fontMono } from '@/lib/fonts';
 
 export const metadata: Metadata = {
   title: 'Numerito — ERP Contable',
   description: 'ERP contable argentino para estudios contables',
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="es">
+    <html lang="es" className={`${fontSans.variable} ${fontMono.variable}`}>
       <head>
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" />
-        <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+        />
       </head>
       <body className="min-h-screen bg-background font-sans antialiased">
         <AuthProvider>{children}</AuthProvider>

--- a/apps/frontend/src/components/redesign/README.md
+++ b/apps/frontend/src/components/redesign/README.md
@@ -1,0 +1,10 @@
+# Redesign Components
+
+Componentes del rediseño en curso. Conviven con los viejos hasta que la migración esté completa (Fase 12).
+
+**Reglas:**
+
+- No importar de `@/components/shared/*` (esos son los viejos); si hace falta algo compartido, copiarlo/reescribirlo acá.
+- Usar solo tokens nuevos (`--surface`, `--text`, `--brand`, etc.) — no colores hardcodeados.
+- Cada componente debe funcionar en light y dark sin excepciones.
+- Los tests van junto al componente: `button.tsx` → `button.spec.tsx`.

--- a/apps/frontend/src/lib/feature-flags.ts
+++ b/apps/frontend/src/lib/feature-flags.ts
@@ -1,0 +1,22 @@
+/**
+ * Feature flags para el frontend.
+ *
+ * Se leen de variables NEXT_PUBLIC_* y quedan inlineadas en build time.
+ * Para activar en dev, poner en .env.local:
+ *    NEXT_PUBLIC_REDESIGN=true
+ */
+
+const flag = (name: string, fallback = false): boolean => {
+  const v = process.env[name];
+  if (v === undefined) return fallback;
+  return v === 'true' || v === '1';
+};
+
+export const FEATURES = {
+  /** Rediseño general (layout, primitivos, pantallas). Se activa por fases. */
+  REDESIGN: flag('NEXT_PUBLIC_REDESIGN', false),
+} as const;
+
+export type FeatureName = keyof typeof FEATURES;
+
+export const isFeatureOn = (name: FeatureName): boolean => FEATURES[name];

--- a/apps/frontend/src/lib/fonts.ts
+++ b/apps/frontend/src/lib/fonts.ts
@@ -1,0 +1,15 @@
+import { Inter, JetBrains_Mono } from 'next/font/google';
+
+export const fontSans = Inter({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-sans',
+  weight: ['400', '500', '600', '700'],
+});
+
+export const fontMono = JetBrains_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-mono',
+  weight: ['400', '500', '600'],
+});


### PR DESCRIPTION
## Summary

Fase 0 del rediseño. Todo aditivo, no hay cambios visuales.

- Añade Inter + JetBrains Mono vía `next/font` (evita fetch en runtime).
- Retira el `<link>` externo a Google Fonts para Inter (Material Symbols se mantiene).
- Nuevo flag `NEXT_PUBLIC_REDESIGN` (default `false`) en `lib/feature-flags.ts`.
- Crea `components/redesign/` con README de convenciones.
- `.env.example` con el flag documentado.
- `globals.css`: `body` ahora usa `var(--font-sans)` (expuesto por next/font).

## Notas

- El proyecto usa Tailwind v4 (no `tailwind.config.ts`); el paso de `extend.fontFamily` del DIFF no aplica — se consume la var via CSS.
- Pre-existing: `pnpm lint` falla porque `next lint` fue deprecado en Next 16. No bloqueante para esta fase; validación hecha con `pnpm build` (verde).

## Test plan

- [x] `pnpm build` verde en `apps/frontend`
- [ ] Con `NEXT_PUBLIC_REDESIGN=true` en `.env.local`, el flag se inlinea en build
- [ ] Body renderiza con Inter (via `var(--font-sans)`)